### PR TITLE
outdated offset for sanitizedplayername, fixed crash when using name esp

### DIFF
--- a/TempleWare-CS2/source/cs2/entity/CCSPlayerController/CCSPlayerController.h
+++ b/TempleWare-CS2/source/cs2/entity/CCSPlayerController/CCSPlayerController.h
@@ -14,7 +14,7 @@ public:
 
 	SCHEMA_ADD_OFFSET(bool, IsLocalPlayer, 0x6F0);
 	SCHEMA_ADD_OFFSET(CBaseHandle, m_hPawn, 0x62C);
-	SCHEMA_ADD_OFFSET(const char*, m_sSanitizedPlayerName, 0x770);
+	SCHEMA_ADD_OFFSET(const char*, m_sSanitizedPlayerName, 0x778);
 
 private:
 	uintptr_t address;


### PR DESCRIPTION
yeah idk if u realised but the name esp was crashing so ya!